### PR TITLE
Remover CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-assinatura.solucaut.com.br


### PR DESCRIPTION
Como o DNS da solucaut não tem mais o record para o github, é melhor retirar esse arquivo e usar o domínio .github.io